### PR TITLE
Fix the error on checkpoint loading

### DIFF
--- a/src/models/emulator.py
+++ b/src/models/emulator.py
@@ -11,7 +11,7 @@ import sys
 sys.path.append("..")
 from utils import get_sep_position
 from .modeling_gpt2_implicit import GPT2LMHeadImplicitModel
-
+import logging
 
 class Emulator(nn.Module):
     def __init__(self, config):
@@ -73,7 +73,11 @@ class Emulator(nn.Module):
         config = EmulatorConfig.from_pretrained(pretrained_path)
         model = Emulator(config)
         state_dict = torch.load(os.path.join(pretrained_path, 'state_dict.bin'))
-        model.load_state_dict(state_dict)
+        try:
+            model.load_state_dict(state_dict)
+        except:
+            model.load_state_dict(state_dict, strict=False)
+            logging.warn("Some weights of the model Emulator checkpoint not loaded.")
         return model
 
     def save_pretrained(self, save_directory):

--- a/src/models/student.py
+++ b/src/models/student.py
@@ -1,6 +1,6 @@
 import sys
 import os
-
+import logging
 import torch
 import torch.nn as nn
 from transformers import AutoTokenizer
@@ -91,7 +91,12 @@ class Student(nn.Module):
         config = StudentConfig.from_pretrained(pretrained_path)
         model = Student(config)
         state_dict = torch.load(os.path.join(pretrained_path, 'state_dict.bin'))
-        model.load_state_dict(state_dict)
+        try:
+            model.load_state_dict(state_dict)
+        except:
+            model.load_state_dict(state_dict, strict=False)
+            logging.warn("Some weights of the model Student checkpoint not loaded.")
+
         return model
 
     def save_pretrained(self, save_directory):


### PR DESCRIPTION
The newest version of huggingface transformers is `4.35.2`, in which the `GPT2Model` doesn't have the weight `h.<layer-id>.attn.bias` and `h.<layer-id>.attn.masked_bias`, while the version of this package in the author's environment might not be.
![image](https://github.com/da03/implicit_chain_of_thought/assets/42952005/621f08bb-b0da-498b-a70d-7a9cad3e3c2c)

Due to this version inconsistency, the code will throw an error when you try to load the checkpoints provided in Google Drive.

![image](https://github.com/da03/implicit_chain_of_thought/assets/42952005/b84937c8-39e1-474c-9f10-e633bffb3b42)

To address this error, I added a try-catch statement in the initialization of the student model and the emulator model, and now the checkpoint can be loaded and the model is behaving well.