### PR TITLE
Resolved  a warning about logging and fixed a typo.

### DIFF
--- a/src/models/modeling_gpt2_implicit.py
+++ b/src/models/modeling_gpt2_implicit.py
@@ -1,5 +1,7 @@
+import logging
 import torch
 import torch.nn as nn
+from torch.nn import CrossEntropyLoss
 from transformers import GPT2Model, GPT2LMHeadModel
 from transformers.modeling_outputs import BaseModelOutputWithPastAndCrossAttentions, CausalLMOutputWithCrossAttentions
 from typing import Optional, Tuple, Union, Dict, Any
@@ -133,7 +135,7 @@ class GPT2ImplicitModel(GPT2Model):
 
         if self.gradient_checkpointing and self.training:
             if use_cache:
-                logger.warning_once(
+                logging.warn(
                     "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
                 )
                 use_cache = False
@@ -248,7 +250,7 @@ class GPT2ImplicitModel(GPT2Model):
                     hidden_states[:, positions_to_substitute[0]] = states_to_substitute[i]
                 else:
                     for batch_id in range(batch_size):
-                        hidden_states[batch_id, positions_to_substitut[batch_id]] = states_to_substitute[i][batch_id]
+                        hidden_states[batch_id, positions_to_substitute[batch_id]] = states_to_substitute[i][batch_id]
 
 
             if self.gradient_checkpointing and self.training:

--- a/src_autoencoder/models/modeling_gpt2_implicit.py
+++ b/src_autoencoder/models/modeling_gpt2_implicit.py
@@ -248,7 +248,7 @@ class GPT2ImplicitModel(GPT2Model):
                     hidden_states[:, positions_to_substitute[0]] = states_to_substitute[i]
                 else:
                     for batch_id in range(batch_size):
-                        hidden_states[batch_id, positions_to_substitut[batch_id]] = states_to_substitute[i][batch_id]
+                        hidden_states[batch_id, positions_to_substitute[batch_id]] = states_to_substitute[i][batch_id]
 
 
             if self.gradient_checkpointing and self.training:


### PR DESCRIPTION
1. Resolve a warning caused by a missing logging method.
2. Fix a typo "positions_to_substitut" that still exists.

Hi, Prof. Deng. I am creating this pull request to bring your attention to my Ph.D. supervision request, which you may have missed.