### PR TITLE
Updated the configuration classes to load local tokenizer of teacher, emulator and student.

### DIFF
--- a/src/models/configuration_emulator.py
+++ b/src/models/configuration_emulator.py
@@ -1,5 +1,5 @@
 from transformers import PretrainedConfig
-
+from os import path
 class EmulatorConfig(PretrainedConfig):
     def __init__(
         self,
@@ -11,6 +11,8 @@ class EmulatorConfig(PretrainedConfig):
     ):
         self.base_model = base_model
         self.tokenizer_name = tokenizer_name
+        if path.exists(base_model):
+            self.tokenizer_name = base_model
         self.mixture_size = mixture_size
         self.softmax_temperature = softmax_temperature
         super().__init__(**kwargs)

--- a/src/models/configuration_student.py
+++ b/src/models/configuration_student.py
@@ -1,4 +1,5 @@
 from transformers import PretrainedConfig
+from os import path
 
 class StudentConfig(PretrainedConfig):
     def __init__(
@@ -10,5 +11,7 @@ class StudentConfig(PretrainedConfig):
     ):
         self.base_model = base_model
         self.tokenizer_name = tokenizer_name
+        if path.exists(base_model):
+            self.tokenizer_name = base_model
         self.mixture_size = mixture_size
         super().__init__(**kwargs)

--- a/src/models/configuration_teacher.py
+++ b/src/models/configuration_teacher.py
@@ -1,5 +1,5 @@
 from transformers import PretrainedConfig
-
+from os import path
 class TeacherConfig(PretrainedConfig):
     def __init__(
         self,
@@ -9,5 +9,7 @@ class TeacherConfig(PretrainedConfig):
     ):
         self.base_model = base_model
         self.tokenizer_name = tokenizer_name
+        if path.exists(base_model):
+            self.tokenizer_name = base_model
         super().__init__(**kwargs)
 

--- a/src/models/modeling_gpt2_implicit.py
+++ b/src/models/modeling_gpt2_implicit.py
@@ -1,5 +1,7 @@
+import logging
 import torch
 import torch.nn as nn
+from torch.nn import CrossEntropyLoss
 from transformers import GPT2Model, GPT2LMHeadModel
 from transformers.modeling_outputs import BaseModelOutputWithPastAndCrossAttentions, CausalLMOutputWithCrossAttentions
 from typing import Optional, Tuple, Union, Dict, Any
@@ -133,7 +135,7 @@ class GPT2ImplicitModel(GPT2Model):
 
         if self.gradient_checkpointing and self.training:
             if use_cache:
-                logger.warning_once(
+                logging.warn(
                     "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
                 )
                 use_cache = False
@@ -248,7 +250,7 @@ class GPT2ImplicitModel(GPT2Model):
                     hidden_states[:, positions_to_substitute[0]] = states_to_substitute[i]
                 else:
                     for batch_id in range(batch_size):
-                        hidden_states[batch_id, positions_to_substitut[batch_id]] = states_to_substitute[i][batch_id]
+                        hidden_states[batch_id, positions_to_substitute[batch_id]] = states_to_substitute[i][batch_id]
 
 
             if self.gradient_checkpointing and self.training:

--- a/src_autoencoder/models/modeling_gpt2_implicit.py
+++ b/src_autoencoder/models/modeling_gpt2_implicit.py
@@ -248,7 +248,7 @@ class GPT2ImplicitModel(GPT2Model):
                     hidden_states[:, positions_to_substitute[0]] = states_to_substitute[i]
                 else:
                     for batch_id in range(batch_size):
-                        hidden_states[batch_id, positions_to_substitut[batch_id]] = states_to_substitute[i][batch_id]
+                        hidden_states[batch_id, positions_to_substitute[batch_id]] = states_to_substitute[i][batch_id]
 
 
             if self.gradient_checkpointing and self.training:


### PR DESCRIPTION
Researchers usually download the huggingface transformers model to local storage to avoid errors when they don't have a stable network connection.
When using training or inference script, SSL error or timeout errors sometimes occurs even if the parameter `--model` is set to the path of the downloaded model, because the code is trying to load the tokenizer from huggingface.

![image](https://github.com/da03/implicit_chain_of_thought/assets/42952005/c30729ef-763b-4e93-b974-8d6a9b11b44a)

![image](https://github.com/da03/implicit_chain_of_thought/assets/42952005/b4c80644-372e-44d3-a098-a15dc6a024f1)


To avoid such errors, I added an 'if' branch to the `__init__` functions of the configuration classes.